### PR TITLE
convert chapter 01 to slides

### DIFF
--- a/01-commits.html
+++ b/01-commits.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Commits</title>
+		<style>
+			body {
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+h1, h2, h3 {
+	font-weight: 400;
+	margin-bottom: 0;
+}
+.remark-slide-content h1 { font-size: 3em; }
+.remark-slide-content h2 { font-size: 2em; }
+.remark-slide-content h3 { font-size: 1.6em; }
+.footnote {
+	position: absolute;
+	bottom: 3em;
+}
+li p { line-height: 1.25em; }
+.red { color: #fa0000; }
+.large { font-size: 2em; }
+a, a > code {
+	color: rgb(249, 38, 114);
+	text-decoration: none;
+}
+code {
+	background: none repeat scroll 0 0 #F8F8FF;
+  border: 1px solid #DEDEDE;
+  border-radius: 3px 	;
+  padding: 0 0.2em;
+}
+.remark-code, .remark-inline-code { font-family: "Bitstream Vera Sans Mono", "Courier", monospace; }
+.remark-code-line-highlighted     { background-color: #373832; }
+.pull-left {
+	float: left;
+	width: 47%;
+}
+.pull-right {
+	float: right;
+	width: 47%;
+}
+.pull-right ~ p {
+	clear: both;
+}
+#slideshow .slide .content code {
+	font-size: 0.8em;
+}
+#slideshow .slide .content pre code {
+	font-size: 0.9em;
+	padding: 15px;
+}
+.main-title, .title {
+	background: #272822;
+	color: #777872;
+	text-shadow: 0 0 20px #333;
+}
+.title h1, .title h2, .main-title h1, .main-title h2 {
+	color: #f3f3f3;
+	line-height: 0.8em;
+}
+/* Custom */
+.remark-code {
+	display: block;
+	padding: 0.5em;
+}
+
+		</style>
+	</head>
+	<body>
+		<textarea id="source">
+class: center, middle, main-title
+
+# Commits
+A commit is a snapshot of a project at a specific point in time. Think of it as
+a &#39;save point&#39; in a video game. If you mess up your project you can go back to
+a working commit.
+
+
+---
+class: center, middle, title
+
+## Practical One
+#### Create a new repository
+Before we create our first commit, we&#39;ll need to create a repository.
+
+Create a new directory.
+
+```bash
+mkdir git-workshop
+cd git-workshop
+```
+Initialize a git repository, we will see a hidden `.git` directory created in
+the current directory. Let&#39;s not focus on that too much at the moment.
+
+```bash
+git init
+# stdout: Initialized empty Git repository in...
+
+ls -a
+# stdout: .    ..   .git
+```
+#### Create a commit
+We have our repository created. Let&#39;s create a new file with some text inside
+it.
+
+```bash
+echo 'Hello, World!' > hello.txt
+```
+We can now add the `hello.txt` file to the staging area, ready to be committed.
+Any future changes to `hello.txt` will not be included in the commit we create,
+unless we add them too.
+
+```bash
+git add hello.txt
+```
+Finally we can create a commit using the contents of the staging area, and
+include a descriptive message of our changes.
+
+```bash
+# Alternatively we can just do 'git commit', which will open up an editor to
+# enter the commit message.
+git commit -m "Add hello.txt"
+```
+We have created a commit, now let&#39;s create another one by making some changes
+to `hello.txt`. We&#39;ll leave this one to you, but our change could look
+something like:
+
+```bash
+echo 'My name is <your-name>!' >> hello.txt
+```
+And let&#39;s commit that update.
+
+```bash
+git add hello.txt
+git commit -m "updated hello.txt"
+```
+#### Viewing commit history
+We have two commits created, let&#39;s take a look at the commit log.
+
+```bash
+# To exit the log simply press 'q'
+git log
+```
+The commits are ordered in reverse chronological order. Each commit item
+contains the SHA-256 hash of the commit, the author, the date the commit was
+authored and the commit message. We can use the SHA-256 hash of the commit to
+reference it when using other git commands.
+
+For example, we can *checkout* a commit:
+
+```bash
+git checkout <commit-sha-1>
+cat hello.txt
+# stdout: Hello, World!
+
+# Use 'git checkout -' to checkout the previous commit.
+git checkout -
+cat hello.txt
+# stdout: Hello, World! My name is <your-name>
+```
+
+---
+## Diving deeper
+We covered quite a lot in the previous practical. Let&#39;s go in depth on some of
+the topics covered.
+
+
+---
+### Adding (Staging) and Committing
+When performing a `git add` we mentioned the &quot;staging area&quot;. This is one of the
+three sections of a git project:
+
+
+- The working directory - This is all the files in your current directory. This
+is where files are modified before being staged.
+- The staging area - This is where changes are added during `git add`, when a
+commit is created the changes in the staging area will be the contents of the
+commit.
+- The repository - Changes that have been committed and persisted.
+
+![Sections of a git project](./img/staging-and-comitting.png)
+
+
+---
+### Lifecycle of files
+There are two states of a file in git:
+
+
+- Tracked files - This is any file that is in the previous commit, or currently
+staged.
+- Untracked files - Any file that is not a tracked file.
+
+A tracked file can be:
+
+
+- Modified: Changes have been made since the previous commit, but are not
+staged.
+- Staged: Changes have been made since the previous commit, and those changes
+are staged.
+- Unmodified: No changes have been made to the file since the last commit.
+
+![File lifecycle](./img/file-lifecycle.png)
+
+
+---
+## Practical Two
+Now we know a bit more about staging and the lifecycle of a file, let&#39;s have a
+look at the lifecycle in action.
+
+First, let&#39;s create a new untracked file.
+
+```bash
+echo 'My favourite colour is <your-favourite-colour>!' > colour.txt
+```
+Now we want to see the status of the current project.
+
+```bash
+git status
+```
+It tells us we have an untracked file called &#39;colour.txt&#39;. As we haven&#39;t
+changed the contents of &#39;hello.txt&#39; it is unmodified and does not show by
+default.
+
+If we `add` &#39;colour.txt&#39; to the staging area and check the status again we will
+see git is now telling us the file is staged or ready to be committed, the file
+is now also tracked.
+
+```bash
+git add colour.txt
+
+git status
+# Note that the output also tells us how to unstage the file, using git reset.
+```
+Now let&#39;s change the contents of &#39;hello.txt&#39;, the file will then become
+modified and this will be shown when running `git status`.
+
+```bash
+echo 'I am doing a Git workshop!' >> hello.txt
+
+git status
+```
+Finally `add` and `commit` all of the changes.
+
+
+---
+class: center, middle, main-title
+
+# Next Section
+[Branches](./02-branches.md)
+
+
+		</textarea>
+		<script src="https://gnab.github.io/remark/downloads/remark-latest.min.js"></script>
+		<script>
+			var slideshow = remark.create();
+		</script>
+		<script></script>
+	</body>
+</html>


### PR DESCRIPTION
@ciaranRoche @JameelB I tested out the [convert to slides](https://github.com/partageit/markdown-to-slides) thing.
Seems to work well. Thinking we can convert them as they are initially and then do any cleanup.

Some of the slides are bigger than the slide itself. We can split those out by adding `---` anywhere we want a break and the tool will split it.

To generate this file I ran `markdown-to-slides 01-commits.md -d true -o 01-commits.html`

Let me know if this will work and I'll go ahead and do the rest. 👍 